### PR TITLE
Use ContainerAwareTrait for Symfony3 support

### DIFF
--- a/Libraries/OpenGraph.php
+++ b/Libraries/OpenGraph.php
@@ -1,13 +1,15 @@
 <?php
 namespace Beyerz\OpenGraphProtocolBundle\Libraries;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @author Lance Bailey
  *
  */
-class OpenGraph extends ContainerAware implements OpenGraphInterface {
+class OpenGraph implements OpenGraphInterface {
+
+    use ContainerAwareTrait;
 
     const FIELD_CLASS = 'class';
     const FIELD_DEFAULT_VALUES = 'default_values';


### PR DESCRIPTION
With Symfony 3.2 the Bundle fails to work with the error:

```
Attempted to load class "ContainerAware" from namespace "Symfony\Component\DependencyInjection".
Did you forget a "use" statement for another namespace?
```

ContainerAware has been deprecated in 2.8 and removed in 3.0 in favor of ContainerAwareTrait: http://stackoverflow.com/questions/34373058/namespace-problems-on-symfony3-upgrade

This change allows Symfony 3.x use of this bundle